### PR TITLE
Update share.ts

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -9,11 +9,19 @@ export const shareStatus = (
   lost: boolean,
   isHardMode: boolean
 ) => {
-  navigator.clipboard.writeText(
-    `${GAME_TITLE} ${solutionIndex} ${lost ? 'X' : guesses.length
+  const textToShare = `${GAME_TITLE} ${solutionIndex} ${lost ? 'X' : guesses.length
     }/${MAX_CHALLENGES}${isHardMode ? '*' : ''}\n\n` +
-    generateEmojiGrid(guesses)
-  )
+    generateEmojiGrid(guesses);
+
+
+  if (navigator.canShare && navigator.share) {
+    const shareData = { text: textToShare };
+    if (navigator.canShare(shareData))
+        navigator.share(shareData);
+  } 
+  else {
+    navigator.clipboard.writeText(textToShare);
+  }
 }
 
 export const generateEmojiGrid = (guesses: string[]) => {


### PR DESCRIPTION
Modified the sharing method to use device sharing when available so pasting into a text, etc. isn't necessary on a mobile device.  Note that running the navigator.share method requires https if trying to verify locally.  